### PR TITLE
Recreated directory inadvertently added to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ yarn.lock
 src/database/docketeerdb
 server/database/docketeerdb
 dist/
-security/
 .env
 
 coverage/

--- a/security/email.js
+++ b/security/email.js
@@ -1,0 +1,6 @@
+module.exports = {
+  host: 'smtp.gmail.com',
+  port: 465,
+  username: 'example@gmail.com',
+  password: 'belugas',
+};

--- a/security/sysadmin.js
+++ b/security/sysadmin.js
@@ -1,0 +1,4 @@
+module.exports = {
+  phone: '',
+  email: '',
+};


### PR DESCRIPTION
The newest members of the team found import statement errors when first pulling from master. Concluded that "security" directory had been placed in gitignore inadvertently. Reinserting "security" directory and the two corresponding files to prevent the issue from occurring again.
